### PR TITLE
Add typescript module definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+declare module "colourlogger" {
+    export function getLogger(): Logger;
+
+    export class Logger {
+        readonly name: string;
+        constructor(name: string);
+        disableLog(): void;
+        disableLogColor(): void;
+        enableLog(): void;
+        enableLogColor(): void;
+        setLevel(level: LogLevel): void;
+        trace(...args: any[]): void;        
+        debug(...args: any[]): void;
+        info (...args: any[]): void;
+        warn (...args: any[]): void;
+        error(...args: any[]): void;
+        fatal(...args: any[]): void;
+    }
+
+    export type LogLevel = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL";
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/wallacegibbon/colourlogger.git"
-  }
+  },
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
First, thanks for creating and sharing your work.  I've created some Typescript definitions for this library.  It would be awesome to use this library in my Typescript projects without having to use my fork.  According to Typescript best practices it is advised to ask the library maintainer to add definitions directly to the npm module.  If you're interested, I'd also be happy to maintain these .d.ts files for you as I'm building a Library based on this module.

Thanks,
Thad